### PR TITLE
Fixed the hazelcast-config file action arrow

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -230,7 +230,7 @@ You can create a named cluster group to limit the Hazelcast instances which
 automatically join the cluster. This is accomplished by creating a Hazelcast
 configuration file.
 
-[role="code_command hotspot", subs="quotes"]
+[role="code_command hotspot file=2", subs="quotes"]
 ----
 #Create a new `hazelcast-config.xml` config file.#
 `src/main/liberty/config/hazelcast-config.xml`


### PR DESCRIPTION
- Addressed the following issue with UI code from `master` branch: 
Under the section "Configuring HazelCast", the action arrow "Create a new hazelcast-config.xml config file." does not highlight the hazelcast-config.xml file
