### PR TITLE
Missing instruction for minikube when using Linux

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -254,6 +254,14 @@ returns a pod name, a session ID, and all the items from your session.
 [role='command']
 include::{common-includes}/devmode-quit.adoc[]
 
+
+// =================================================================================================
+// Staring and preparing your cluster for deployment
+// =================================================================================================
+[role='command']
+include::{common-includes}/kube-start.adoc[]
+
+
 == Containerizing the application
 
 Before you can deploy the application to Kubernetes, you need to containerize it with Docker.
@@ -294,11 +302,6 @@ cart-app                        1.0-SNAPSHOT
 openliberty/open-liberty        kernel-java8-openj9-ubi
 ----
 
-// =================================================================================================
-// Staring and preparing your cluster for deployment
-// =================================================================================================
-[role='command']
-include::{common-includes}/kube-start.adoc[]
 
 == Deploying and running the application in Kubernetes
 
@@ -334,6 +337,7 @@ cart-deployment-98f4ff789-2xlhs  1/1    Running  0         17s
 cart-deployment-98f4ff789-6rvfj  1/1    Running  0         17s
 cart-deployment-98f4ff789-qrh45  1/1    Running  0         17s
 ----
+
 
 include::{common-includes}/os-tabs.adoc[]
 

--- a/README.adoc
+++ b/README.adoc
@@ -350,7 +350,7 @@ This URL displays the available REST endpoints.
 [.tab_content.linux_section]
 --
 Run the `minikube ip` command to find out the host name for minikube.
-Point your browser to the `\http://[hostname]:31000/openapi/ui/` URL. 
+Point your browser to the `http://[hostname]:31000/openapi/ui/` URL. 
 This URL displays the available REST endpoints.
 --
 

--- a/README.adoc
+++ b/README.adoc
@@ -349,8 +349,8 @@ This URL displays the available REST endpoints.
 
 [.tab_content.linux_section]
 --
-Run the `minikube ip` command to find out the host name for minikube.
-Point your browser to the `http://[hostname]:31000/openapi/ui/` URL. 
+Run the `minikube ip` command to get the hostname for minikube.
+Then, go to the `http://[hostname]:31000/openapi/ui/` URL in your browser. 
 This URL displays the available REST endpoints.
 --
 

--- a/README.adoc
+++ b/README.adoc
@@ -294,6 +294,11 @@ cart-app                        1.0-SNAPSHOT
 openliberty/open-liberty        kernel-java8-openj9-ubi
 ----
 
+// =================================================================================================
+// Staring and preparing your cluster for deployment
+// =================================================================================================
+[role='command']
+include::{common-includes}/kube-start.adoc[]
 
 == Deploying and running the application in Kubernetes
 
@@ -330,8 +335,20 @@ cart-deployment-98f4ff789-6rvfj  1/1    Running  0         17s
 cart-deployment-98f4ff789-qrh45  1/1    Running  0         17s
 ----
 
-Point your browser to the link:http://localhost:31000/openapi/ui/[^] URL. This
-URL displays the available REST endpoints.
+include::{common-includes}/os-tabs.adoc[]
+
+[.tab_content.windows_section.mac_section]
+--
+Point your browser to the link:http://localhost:31000/openapi/ui/[^] URL.
+This URL displays the available REST endpoints.
+--
+
+[.tab_content.linux_section]
+--
+Run the `minikube ip` command to find out the host name for minikube.
+Point your browser to the `\http://[hostname]:31000/openapi/ui/` URL. 
+This URL displays the available REST endpoints.
+--
 
 Make a POST request to the `/cart/{item}&{price}` endpoint. To make this request, expand the POST
 endpoint on the UI, click the `Try it out` button, provide an item and a price,


### PR DESCRIPTION
- add instruction to start minikube
- update instruction to the openapi/ui url