### PR TITLE
Merge staging to prod - Bump hazelcast from 3.12.12 to 4.0.5 in /start (#126)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: bash ./tools/pr-checker/checker.sh ${{ github.repository }} ${{ github.event.pull_request.number }} | tee checker.log 
       - id: Lint-Code-Base
         if: always()
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.17.0
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.12.12</version>
+            <version>4.0.5</version>
             <scope>test</scope>
         </dependency>
         

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.12.12</version>
+            <version>4.0.5</version>
             <scope>test</scope>
         </dependency>
         


### PR DESCRIPTION
* Bump hazelcast from 3.12.12 to 4.0.5 in /start

Bumps [hazelcast](https://github.com/hazelcast/hazelcast) from 3.12.12 to 4.0.5.
- [Release notes](https://github.com/hazelcast/hazelcast/releases)
- [Commits](https://github.com/hazelcast/hazelcast/compare/v3.12.12...v4.0.5)

---
updated-dependencies:
- dependency-name: com.hazelcast:hazelcast
  dependency-type: direct:development
...

Signed-off-by: dependabot[bot] <support@github.com>

* Bump hazelcast from 3.12.12 to 4.0.5 in /finish

Bumps [hazelcast](https://github.com/hazelcast/hazelcast) from 3.12.12 to 4.0.5.
- [Release notes](https://github.com/hazelcast/hazelcast/releases)
- [Commits](https://github.com/hazelcast/hazelcast/compare/v3.12.12...v4.0.5)

---
updated-dependencies:
- dependency-name: com.hazelcast:hazelcast
  dependency-type: direct:development
...

Signed-off-by: dependabot[bot] <support@github.com>

* Update test.yml

Co-authored-by: Gilbert Kwan <gkwan@ca.ibm.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>