### PR TITLE
Temporarily use Open Liberty 22.0.0.2

### DIFF
--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -1,4 +1,5 @@
-FROM icr.io/appcafe/open-liberty:full-java11-openj9-ubi
+FROM icr.io/appcafe/open-liberty:22.0.0.2-full-java11-openj9-ubi
+
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -84,6 +84,9 @@
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>3.5.1</version>
+                <configuration>
+                    <liberty.runtime.version>22.0.0.2</liberty.runtime.version>
+                </configuration>
             </plugin>
             
             <!-- Copy the hazelcast library -->

--- a/start/Dockerfile
+++ b/start/Dockerfile
@@ -1,4 +1,4 @@
-FROM icr.io/appcafe/open-liberty:full-java11-openj9-ubi
+FROM icr.io/appcafe/open-liberty:22.0.0.2-full-java11-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -85,6 +85,9 @@
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <version>3.5.1</version>
+                <configuration>
+                    <liberty.runtime.version>22.0.0.2</liberty.runtime.version>
+                </configuration>
             </plugin>
             
             <!-- Copy the hazelcast library -->


### PR DESCRIPTION
Because openapi/ui not work well in OL 22.0.0.3, temporarily use Open Liberty 22.0.0.2.