### PR TITLE
Merge staging to prod - Bump hazelcast from 5.2.3 to 5.3.0 in /finish (#173)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022 IBM Corporation and others.
+// Copyright (c) 2019, 2023 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -223,7 +223,7 @@ hazelcast-config.xml
 include::finish/src/main/liberty/config/hazelcast-config.xml[]
 ----
 
-The cluster name [hotspot=cartCluster file=1]`CartCluster` is defined in the [hotspot file=1]`hazelcast-config.xml`.
+The [hotspot=cartCluster file=1]`CartCluster` cluster name is defined in the [hotspot file=1]`hazelcast-config.xml` file. To allow Hazelcast cluster members to find each other, enable the [hotspot=multicast file=1]`multicast` communication in the [hotspot=network file=1]`network` configuration.
 
 In the [hotspot file=0]`server.xml` file, a reference to the Hazelcast configuration file is made by using
 the [hotspot=httpSessionCache file=0]`httpSessionCache` tag.
@@ -424,7 +424,7 @@ You see a message similar to the following:
 
 [role="no_copy"]
 ----
-... [10.1.0.46]:5701 [CartCluster] [3.11.2]
+... [10.1.0.46]:5701 [CartCluster] [5.3.0]
 
 Members {size:3, ver:3} [
 	Member [10.1.0.40]:5701 - 01227d80-501e-4789-ae9d-6fb348d794ea

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -19,6 +19,6 @@ LABEL \
 
 COPY --chown=1001:0 src/main/liberty/config /config/
 COPY --chown=1001:0 target/guide-sessions.war /config/apps
-COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.1.1.jar /opt/ol/wlp/usr/shared/resources
+COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.3.0.jar /opt/ol/wlp/usr/shared/resources
 
 RUN configure.sh

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.2.3</version>
+            <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
         
@@ -92,7 +92,7 @@
                             <dependency>
                                 <groupId>com.hazelcast</groupId>
                                 <artifactId>hazelcast</artifactId>
-                                <version>5.1.1</version>
+                                <version>5.3.0</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>

--- a/finish/src/main/liberty/config/hazelcast-config.xml
+++ b/finish/src/main/liberty/config/hazelcast-config.xml
@@ -1,6 +1,6 @@
 <!-- tag::copyright[] -->
 <!-- 
-     Copyright (c) 2019, 2021 IBM Corporation and others. 
+     Copyright (c) 2019, 2023 IBM Corporation and others. 
      All rights reserved. This program and the accompanying materials 
      are made available under the terms of the Eclipse Public License 2.0
      which accompanies this distribution, and is available at
@@ -12,10 +12,20 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.hazelcast.com/schema/config
-       https://hazelcast.com/schema/config/hazelcast-config-5.1.xsd">
+       https://hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
 
-    <!--  tag::cartCluster[] -->
+    <!-- tag::cartCluster[] -->
     <cluster-name>CartCluster</cluster-name>
-    <!--  end::cartCluster[] -->
+    <!-- end::cartCluster[] -->
+
+    <!-- tag::network[] -->
+    <network>
+        <join>
+           <!-- tag::multicast[] -->
+           <multicast enabled="true"/>
+           <!-- end::multicast[] -->
+        </join>
+    </network>
+    <!-- end::network[] -->
 
 </hazelcast>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -1,6 +1,6 @@
 <!-- tag::copyright[] -->
 <!-- 
-     Copyright (c) 2019, 2021 IBM Corporation and others. 
+     Copyright (c) 2019, 2023 IBM Corporation and others. 
      All rights reserved. This program and the accompanying materials 
      are made available under the terms of the Eclipse Public License 2.0
      which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@
     <!-- tag::library[] -->
     <library id="jCacheVendorLib">
     	<!-- tag::hazelcastjar[] -->
-        <file name="${shared.resource.dir}/hazelcast-5.1.1.jar" />
+        <file name="${shared.resource.dir}/hazelcast-5.3.0.jar" />
         <!-- end::hazelcastjar[] -->
     </library>
     <!-- end::library[] -->

--- a/start/Dockerfile
+++ b/start/Dockerfile
@@ -18,6 +18,6 @@ LABEL \
 
 COPY --chown=1001:0 src/main/liberty/config /config/
 COPY --chown=1001:0 target/guide-sessions.war /config/apps
-COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.1.1.jar /opt/ol/wlp/usr/shared/resources
+COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.3.0.jar /opt/ol/wlp/usr/shared/resources
 
 RUN configure.sh

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.2.3</version>
+            <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
         
@@ -92,7 +92,7 @@
                             <dependency>
                                 <groupId>com.hazelcast</groupId>
                                 <artifactId>hazelcast</artifactId>
-                                <version>5.1.1</version>
+                                <version>5.3.0</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>


### PR DESCRIPTION
* Bump hazelcast from 5.2.3 to 5.3.0 in /start

Bumps [hazelcast](https://github.com/hazelcast/hazelcast) from 5.2.3 to 5.3.0.
- [Release notes](https://github.com/hazelcast/hazelcast/releases)
- [Commits](https://github.com/hazelcast/hazelcast/compare/v5.2.3...v5.3.0)

---
updated-dependencies:
- dependency-name: com.hazelcast:hazelcast dependency-type: direct:development ...



* Bump hazelcast from 5.2.3 to 5.3.0 in /finish

Bumps [hazelcast](https://github.com/hazelcast/hazelcast) from 5.2.3 to 5.3.0.
- [Release notes](https://github.com/hazelcast/hazelcast/releases)
- [Commits](https://github.com/hazelcast/hazelcast/compare/v5.2.3...v5.3.0)

---
updated-dependencies:
- dependency-name: com.hazelcast:hazelcast dependency-type: direct:development ...



* Update pom.xml

Update the copyDependency

* Update pom.xml

* update server.xml to use latest hazelcast library

* update Dockerfile to use latest hazelcast library

* update hazelcast-config.xml to use latest xsd

* enable multicast

* enable multicast

* Update README.adoc



* Update README.adoc

remove a space

---------