### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2023 IBM Corporation and others.
+// Copyright (c) 2019, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -12,7 +12,7 @@
 :page-releasedate: 2019-07-23
 :page-description: Learn how to create, use and cache HTTP session data.
 :guide-author: Open Liberty
-:page-tags: ['Docker']
+:page-tags: ['docker']
 :page-related-guides: ['rest-intro', 'microprofile-openapi', 'kubernetes-intro']
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
@@ -255,7 +255,7 @@ https://docs.hazelcast.org/docs/latest/manual/html-single/#understanding-configu
 [role="command"]
 include::{common-includes}/devmode-lmp33-start.adoc[]
 
-Point your browser to the link:http://localhost:9080/openapi/ui/[^] URL.
+Point your browser to the link:http://localhost:9090/openapi/ui/[^] URL.
 This URL displays the available REST endpoints.
 
 First, make a POST request to the `/cart/{item}&{price}` endpoint. To make this request, expand the POST

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -20,6 +20,6 @@ LABEL \
 COPY --chown=1001:0 src/main/liberty/config /config/
 RUN features.sh
 COPY --chown=1001:0 target/guide-sessions.war /config/apps
-COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.3.0.jar /opt/ol/wlp/usr/shared/resources
+COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.3.6.jar /opt/ol/wlp/usr/shared/resources
 
 RUN configure.sh

--- a/finish/kubernetes.yaml
+++ b/finish/kubernetes.yaml
@@ -19,7 +19,7 @@ spec:
         image: cart-app:1.0-SNAPSHOT
         ports:
         - name: http
-          containerPort: 9080
+          containerPort: 9090
         - name: hazelcast
           containerPort: 5701
 ---
@@ -33,6 +33,6 @@ spec:
     app: cart
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 31000

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
         <hazelcast.path>${user.home}/.m2/repository/com/hazelcast/hazelcast/</hazelcast.path>
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
         <liberty.var.app.context.root>${project.artifactId}</liberty.var.app.context.root>
     </properties>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.3.0</version>
+            <version>5.3.6</version>
             <scope>test</scope>
         </dependency>
         
@@ -46,19 +46,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
                 <!-- tag::configuration[] -->
                 <configuration>
                     <!-- Copy the hazelcast library -->
@@ -92,7 +92,7 @@
                             <dependency>
                                 <groupId>com.hazelcast</groupId>
                                 <artifactId>hazelcast</artifactId>
-                                <version>5.3.0</version>
+                                <version>5.3.6</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>
@@ -104,17 +104,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -1,6 +1,6 @@
 <!-- tag::copyright[] -->
 <!-- 
-     Copyright (c) 2019, 2023 IBM Corporation and others. 
+     Copyright (c) 2019, 2024 IBM Corporation and others. 
      All rights reserved. This program and the accompanying materials 
      are made available under the terms of the Eclipse Public License 2.0
      which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@
     <!-- tag::library[] -->
     <library id="jCacheVendorLib">
     	<!-- tag::hazelcastjar[] -->
-        <file name="${shared.resource.dir}/hazelcast-5.3.0.jar" />
+        <file name="${shared.resource.dir}/hazelcast-5.3.6.jar" />
         <!-- end::hazelcastjar[] -->
     </library>
     <!-- end::library[] -->

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -22,11 +22,11 @@
         <feature>mpOpenAPI-3.1</feature>
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9090"/>
+    <variable name="https.port" defaultValue="9453"/>
     <variable name="app.context.root" defaultValue="guide-sessions"/>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
         id="defaultHttpEndpoint" host="*" />
     <!-- tag::httpSessionCache[] -->
     <httpSessionCache libraryRef="jCacheVendorLib"

--- a/start/Dockerfile
+++ b/start/Dockerfile
@@ -19,6 +19,6 @@ LABEL \
 COPY --chown=1001:0 src/main/liberty/config /config/
 RUN features.sh
 COPY --chown=1001:0 target/guide-sessions.war /config/apps
-COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.3.0.jar /opt/ol/wlp/usr/shared/resources
+COPY --chown=1001:0 target/liberty/wlp/usr/shared/resources/hazelcast-5.3.6.jar /opt/ol/wlp/usr/shared/resources
 
 RUN configure.sh

--- a/start/kubernetes.yaml
+++ b/start/kubernetes.yaml
@@ -17,7 +17,7 @@ spec:
         image: cart-app:1.0-SNAPSHOT
         ports:
         - name: http
-          containerPort: 9080
+          containerPort: 9090
         - name: hazelcast
           containerPort: 5701
 ---
@@ -31,6 +31,6 @@ spec:
     app: cart
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 31000

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
         <hazelcast.path>${user.home}/.m2/repository/com/hazelcast/hazelcast/</hazelcast.path>
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
         <liberty.var.app.context.root>${project.artifactId}</liberty.var.app.context.root>
     </properties>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.3.0</version>
+            <version>5.3.6</version>
             <scope>test</scope>
         </dependency>
         
@@ -46,19 +46,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
                 <configuration>
                     <!-- Copy the hazelcast library -->
                     <copyDependencies>
@@ -92,7 +92,7 @@
                             <dependency>
                                 <groupId>com.hazelcast</groupId>
                                 <artifactId>hazelcast</artifactId>
-                                <version>5.3.0</version>
+                                <version>5.3.6</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>
@@ -103,17 +103,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

